### PR TITLE
Fix bad javadoc and sources signatures during deploy [#5]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,23 +61,21 @@
             </activation>
             <build>
                 <plugins>
+                    <!-- plugin sequence: javadoc, sources, gpg, deploy -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <configuration>
-                            <passphrase>${gpg.passphrase}</passphrase>
-                        </configuration>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.3</version>
                         <executions>
                             <execution>
-                                <id>sign-artifacts</id>
+                                <id>attach-javadocs</id>
                                 <phase>verify</phase>
                                 <goals>
-                                    <goal>sign</goal>
+                                    <goal>jar</goal>
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin><!-- maven-gpg-plugin -->
+                    </plugin><!-- maven-javadoc-plugin -->
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -96,18 +94,21 @@
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.10.3</version>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <configuration>
+                            <passphrase>${gpg.passphrase}</passphrase>
+                        </configuration>
                         <executions>
                             <execution>
-                                <id>attach-javadocs</id>
+                                <id>sign-artifacts</id>
                                 <phase>verify</phase>
                                 <goals>
-                                    <goal>jar</goal>
+                                    <goal>sign</goal>
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin><!-- maven-javadoc-plugin -->
+                    </plugin><!-- maven-gpg-plugin -->
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The javadoc and sources jar files were being signed before they were built.

Order of build plugins in release profile modified to sign them after they
are created.

Signed-off-by: Paul Campbell <pcampbell@kemitix.net>