### PR TITLE
Add digraph-dependency-maven-plugin 0.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+jdk:
+    - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -170,6 +170,17 @@ classes.
 
 The plugin will `analyse` the project during the `verify` phase.
 
+## Digraph Dependency Plugin
+
+The [Digraph Dependency Plugin](https://github.com/kemitix/digraph-dependency-maven-plugin)
+generates a DOT file diagram showing the dependencies between packages in a project.
+
+### Configuration
+
+The plugin will generate the `target/digraph.dot` file during the `verify` phase.
+
+The plugin will filter to packages within the `net.kemitix` package namespace.
+
 # Distribution Management
 
 Remote repositories are provided for the Sonatype Nexus Snapshots and Nexus Release

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,21 @@
                     </execution>
                 </executions>
             </plugin><!-- highwheel-maven -->
+
+            <plugin>
+                <groupId>net.kemitix</groupId>
+                <artifactId>digraph-dependency-maven-plugin</artifactId>
+                <version>0.1.0</version>
+                <configuration>
+                    <basePackage>net.kemitix</basePackage>
+                </configuration>
+                <executions>
+                    <phase>validate</phase>
+                    <goals>
+                        <goal>digraph</goal>
+                    </goals>
+                </executions>
+            </plugin><!-- digraph-dependency-maven-plugin -->
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -322,10 +322,12 @@
                     <basePackage>net.kemitix</basePackage>
                 </configuration>
                 <executions>
-                    <phase>validate</phase>
-                    <goals>
-                        <goal>digraph</goal>
-                    </goals>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>digraph</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin><!-- digraph-dependency-maven-plugin -->
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
             <plugin>
                 <groupId>net.kemitix</groupId>
                 <artifactId>digraph-dependency-maven-plugin</artifactId>
-                <version>0.1.0</version>
+                <version>0.1.2</version>
                 <configuration>
                     <basePackage>net.kemitix</basePackage>
                 </configuration>


### PR DESCRIPTION
Digraph generator for package dependencies within a project

Build Plugin to create a DOT format diagram showing the dependencies between the packages in a project.

It works by scanning the source code and processing import statements.

Signed-off-by: Paul Campbell <pcampbell@kemitix.net>