### PR TITLE
Upgrade checkstyle to 6.14.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>6.13</version>
+                            <version>6.14.1</version>
                         </dependency>
                     </dependencies>
                 </plugin><!-- maven-checkstyle-plugin -->


### PR DESCRIPTION
From 6.14 Release Notes:

  Breaking backward compatibility:

    Remove parameters validation from LocalVariableName.
    [#2549](https://github.com/checkstyle/checkstyle/issues/2549)

Signed-off-by: Paul Campbell <paulcampbell@fife.ac.uk>