### PR TITLE
pom.xml: upgrade maven-{surefire,failsafe}-plugin to 2.19.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,13 +169,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
             </plugin><!-- maven-surefire-plugin -->
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
                 <executions>
                     <execution>
                         <id>integration-test</id>
@@ -356,7 +356,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
             </plugin><!-- maven-surefire-report-plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Bug fix now supports full class name when running single tests. This behaviour was broken in 2.19.0 and meant single tests couldn't be run from within Netbeans. This is now fixed in 2.19.1.