### PR TITLE
pom.xml: Remove release profile property activation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,6 @@
     <profiles>
         <profile>
             <id>release</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
             <build>
                 <plugins>
                     <!-- plugin sequence: javadoc, sources, gpg, deploy -->


### PR DESCRIPTION
Profile should be activated from the maven command line, e.g.:

  mvn -P release clean deploy

Signed-off-by: Paul Campbell <paulcampbell@fife.ac.uk>