### PR TITLE
pom.xml: upgrade findbugs-maven-plugin to 3.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>2.19.1</maven-failsafe-plugin.version>
         <maven-pmd-plugin.version>3.6</maven-pmd-plugin.version>
-        <findbugs-maven-plugin.version>3.0.3</findbugs-maven-plugin.version>
+        <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
         <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
         <highwheel-maven.version>1.2</highwheel-maven.version>
         <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>


### PR DESCRIPTION
Required for Maven 3.4 compatibility.