### PR TITLE
pom.xml: remove redundant maven-project-info-reports-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
         <huntbugs.version>0.0.11</huntbugs.version>
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <highwheel-maven.version>1.2</highwheel-maven.version>
-        <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
         <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
 
         <jacoco-class-line-covered-ratio>0.50</jacoco-class-line-covered-ratio>
@@ -364,11 +363,6 @@
 
     <reporting>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>${maven-project-info-reports-plugin.version}</version>
-            </plugin><!-- maven-project-info-reports-plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>


### PR DESCRIPTION
This plugin is already embodied within maven and doesn't need to be specified. Simply run `mvn site`.