### PR TITLE
Upgrades Spring Cloud to Camden.SR6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
         <lombok.version>1.16.14</lombok.version>
         <spring-platform.version>Brussels-SR1</spring-platform.version>
-        <spring-cloud.version>Camden.SR5</spring-cloud.version>
+        <spring-cloud.version>Camden.SR6</spring-cloud.version>
         <spring-data.version>Ingalls-SR1</spring-data.version>
 
         <digraph-dependency.version>0.9.0</digraph-dependency.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <kemitix-checkstyle-ruleset.level>5-complexity</kemitix-checkstyle-ruleset.level>
 
         <lombok.version>1.16.14</lombok.version>
+        <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
         <spring-platform.version>Brussels-SR1</spring-platform.version>
         <spring-cloud.version>Camden.SR6</spring-cloud.version>
         <spring-data.version>Ingalls-SR1</spring-data.version>


### PR DESCRIPTION
* Upgrade Spring Cloud to Camden.SR6
* Specify Spring Boot version in properties (i.e. `spring-boot.version`)

Closes #64 