### PR TITLE
BREAKING pom.xml: remove spring dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ desired value.
 * kemitix-checkstyle-ruleset.version
 * kemitix-checkstyle-ruleset.level
 * lombok.version
-* spring-boot.version
-* spring-platform.version
-* spring-cloud.version
-* spring-data.version
 * digraph-dependency.version
 * digraph-dependency.basePackage
 * maven-javadoc-plugin.version

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>net.kemitix</groupId>
     <artifactId>kemitix-parent</artifactId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Kemitix Parent</name>
@@ -45,10 +45,6 @@
         <kemitix-checkstyle-ruleset.level>5-complexity</kemitix-checkstyle-ruleset.level>
 
         <lombok.version>1.16.16</lombok.version>
-        <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
-        <spring-platform.version>Brussels-SR2</spring-platform.version>
-        <spring-cloud.version>Dalston.RELEASE</spring-cloud.version>
-        <spring-data.version>Ingalls-SR3</spring-data.version>
 
         <digraph-dependency.version>0.9.0</digraph-dependency.version>
         <digraph-dependency.basePackage>net.kemitix</digraph-dependency.basePackage>
@@ -80,32 +76,6 @@
             <organizationUrl>https://github.com/kemitix/</organizationUrl>
         </developer>
     </developers>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.spring.platform</groupId>
-                <artifactId>platform-bom</artifactId>
-                <version>${spring-platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring-cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.data</groupId>
-                <artifactId>spring-data-releasetrain</artifactId>
-                <version>${spring-data.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
No longer provide dependency management for spring projects. Individual projects must provide their own entries.