### PR TITLE
Update Jenksinfile to latest template

### DIFF
--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -20,6 +20,7 @@ pipeline {
             }
         }
         stage('Static Code Analysis') {
+            when { expression { findFiles(glob: '**/src/main/java/*.java').length > 0 } }
             steps {
                 withMaven(maven: 'maven 3.5.2', jdk: 'JDK 1.8') {
                     sh "${mvn} compile checkstyle:checkstyle pmd:pmd"
@@ -46,6 +47,7 @@ pipeline {
             }
         }
         stage('Test Results') {
+            when { expression { findFiles(glob: '**/target/surefire-reports/*.xml').length > 0 } }
             steps {
                 junit '**/target/surefire-reports/*.xml'
                 jacoco exclusionPattern: '**/*{Test|IT|Main|Application|Immutable}.class'
@@ -59,6 +61,7 @@ pipeline {
             }
         }
         stage('Archiving') {
+            when { expression { findFiles(glob: '**/target/*.jar').length > 0 } }
             steps {
                 archiveArtifacts '**/target/*.jar'
             }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -13,7 +13,8 @@ pipeline {
             when {
                 expression {
                     (env.GIT_BRANCH == 'master' || env.CHANGE_TARGET == 'master') &&
-                            (readMavenPom(file: 'pom.xml').version).contains("SNAPSHOT") }
+                            (readMavenPom(file: 'pom.xml').version).contains("SNAPSHOT")
+                }
             }
             steps {
                 error("Build failed because SNAPSHOT version")
@@ -28,21 +29,17 @@ pipeline {
                 pmd canComputeNew: false, defaultEncoding: '', healthy: '', pattern: '', unHealthy: ''
             }
         }
-        stage('Build') {
-            parallel {
-                stage('Java 8') {
-                    steps {
-                        withMaven(maven: 'maven 3.5.2', jdk: 'JDK 1.8') {
-                            sh "${mvn} clean install"
-                        }
-                    }
+        stage('Build Java 8') {
+            steps {
+                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 1.8') {
+                    sh "${mvn} clean install"
                 }
-                stage('Java 9') {
-                    steps {
-                        withMaven(maven: 'maven 3.5.2', jdk: 'JDK 9') {
-                            sh "${mvn} clean install"
-                        }
-                    }
+            }
+        }
+        stage('Build Java 9') {
+            steps {
+                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 9') {
+                    sh "${mvn} clean install"
                 }
             }
         }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -29,16 +29,16 @@ pipeline {
                 pmd canComputeNew: false, defaultEncoding: '', healthy: '', pattern: '', unHealthy: ''
             }
         }
-        stage('Build Java 8') {
+        stage('Build Java 9') {
             steps {
-                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 1.8') {
+                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 9') {
                     sh "${mvn} clean install"
                 }
             }
         }
-        stage('Build Java 9') {
+        stage('Build Java 8') {
             steps {
-                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 9') {
+                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 1.8') {
                     sh "${mvn} clean install"
                 }
             }

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -3,34 +3,70 @@ final String mvn = "mvn --batch-mode --update-snapshots"
 pipeline {
     agent any
     stages {
+        stage('Environment') {
+            steps {
+                sh 'set'
+            }
+        }
         stage('no SNAPSHOT in master') {
-            // checks that the pom version is not a snapshot when the current branch is master
-            // TODO: also check for SNAPSHOT when is a pull request with master as the target branch
+            // checks that the pom version is not a snapshot when the current or target branch is master
             when {
                 expression {
-                    (env.GIT_BRANCH == 'master') &&
+                    (env.GIT_BRANCH == 'master' || env.CHANGE_TARGET == 'master') &&
                             (readMavenPom(file: 'pom.xml').version).contains("SNAPSHOT") }
             }
             steps {
                 error("Build failed because SNAPSHOT version")
             }
         }
-        stage('Build') {
+        stage('Static Code Analysis') {
             steps {
-                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 9') {
-                    sh 'mvn clean install'
+                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 1.8') {
+                    sh "${mvn} compile checkstyle:checkstyle pmd:pmd"
+                }
+                pmd canComputeNew: false, defaultEncoding: '', healthy: '', pattern: '', unHealthy: ''
+            }
+        }
+        stage('Build') {
+            parallel {
+                stage('Java 8') {
+                    steps {
+                        withMaven(maven: 'maven 3.5.2', jdk: 'JDK 1.8') {
+                            sh "${mvn} clean install"
+                        }
+                    }
+                }
+                stage('Java 9') {
+                    steps {
+                        withMaven(maven: 'maven 3.5.2', jdk: 'JDK 9') {
+                            sh "${mvn} clean install"
+                        }
+                    }
+                }
+            }
+        }
+        stage('Test Results') {
+            steps {
+                junit '**/target/surefire-reports/*.xml'
+                jacoco exclusionPattern: '**/*{Test|IT|Main|Application|Immutable}.class'
+                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 1.8') {
+                    sh "${mvn} com.gavinmogan:codacy-maven-plugin:coverage " +
+                            "-DcoverageReportFile=target/site/jacoco/jacoco.xml " +
+                            "-DprojectToken=`$JENKINS_HOME/codacy/token` " +
+                            "-DapiToken=`$JENKINS_HOME/codacy/apitoken` " +
+                            "-Dcommit=`git rev-parse HEAD`"
                 }
             }
         }
         stage('Archiving') {
             steps {
-                archiveArtifacts 'pom.xml'
+                archiveArtifacts '**/target/*.jar'
             }
         }
         stage('Deploy') {
-            when { expression { (env.GIT_BRANCH == 'master') } }
+            when { expression { (env.GIT_BRANCH == 'master' && env.GIT_URL.startsWith('https://')) } }
             steps {
-                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 9') {
+                withMaven(maven: 'maven 3.5.2', jdk: 'JDK 1.8') {
                     sh "${mvn} deploy --activate-profiles release -DskipTests=true"
                 }
             }


### PR DESCRIPTION
* report environment variable values
* abort if `SNAPSHOT` version when on `master` branch or in a pull request into `master`
* don't invoke code analysis, testing or archiving unless relevant files are present
* stop trying to build under Java 8 and 9 in parallel - they are overwriting each other
* build under Java 9 first to verify compatibility, then  build and deploy from Java 8